### PR TITLE
heap: Make allocate() generic against FromRawFd

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,8 @@ This library provides a safe abstraction over this interface for Rust.
 let heap = DmaBufHeap::new(DmaBufHeapType::CMA)
     .unwrap();
 
-let buffer = heap.allocate(1024).unwrap();
+// Buffer will automatically be freed when `buffer_file` goes out of scope.
+let buffer_file: File = heap.allocate(1024).unwrap();
+// Buffer lifetime must be manually managed.
+let buffer_rawfd: RawFd = heap.allocate(1024).unwrap();
 ```


### PR DESCRIPTION
Users will likely want to embed the file descriptors into some structure
that manages buffer lifetime. Make this process safer by making
allocate() able to return any type that implements FromRawFd. We can
perform the (unsafe) conversion after confirming that the allocation has
succeeded and thus spare the caller from adding its own unsafe block for
it.

Signed-off-by: Alexandre Courbot <gnurou@gmail.com>