### PR TITLE
fix: build for android

### DIFF
--- a/src/ioctl.rs
+++ b/src/ioctl.rs
@@ -6,7 +6,7 @@ use std::{
 use rustix::{
     fs::OFlags,
     io::Errno,
-    ioctl::{Updater, ioctl, opcode},
+    ioctl::{Opcode, Updater, ioctl, opcode},
 };
 
 const DMA_HEAP_IOC_MAGIC: u8 = b'H';
@@ -21,7 +21,7 @@ struct dma_heap_allocation_data {
     heap_flags: u64,
 }
 
-const DMA_HEAP_IOC_ALLOC_OPCODE: u32 =
+const DMA_HEAP_IOC_ALLOC_OPCODE: Opcode =
     opcode::read_write::<dma_heap_allocation_data>(DMA_HEAP_IOC_MAGIC, DMA_HEAP_IOC_ALLOC);
 
 fn dma_heap_alloc_ioctl(fd: BorrowedFd<'_>, data: &mut dma_heap_allocation_data) -> io::Result<()> {


### PR DESCRIPTION
On Android, `rustix::ioctl::Opcode` is i32 and not u32 as on Linux. That causes the build for android to fail(see below). Fix the build failure by using `Opcode` instead of u32.

Failed build log:
```
error[E0308]: mismatched types
  --> dma-heap/src/ioctl.rs:25:5
   |
25 |     opcode::read_write::<dma_heap_allocation_data>(DMA_HEAP_IOC_MAGIC, DMA_HEAP_IOC_ALLOC);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
  --> dma-heap/src/ioctl.rs:31:28
   |
31 |         unsafe { Updater::<DMA_HEAP_IOC_ALLOC_OPCODE, dma_heap_allocation_data>::new(data) };
   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `i32`, found `u32`
---
 src/ioctl.rs | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)

diff --git a/src/ioctl.rs b/src/ioctl.rs
index ecf822a..99c5e6e 100644
--- a/src/ioctl.rs
+++ b/src/ioctl.rs
@@ -6,7 +6,7 @@ use std::{
 use rustix::{
     fs::OFlags,
     io::Errno,
-    ioctl::{Updater, ioctl, opcode},
+    ioctl::{Updater, ioctl, opcode, Opcode},
 };

 const DMA_HEAP_IOC_MAGIC: u8 = b'H';
@@ -21,7 +21,7 @@ struct dma_heap_allocation_data {
     heap_flags: u64,
 }

-const DMA_HEAP_IOC_ALLOC_OPCODE: u32 =
+const DMA_HEAP_IOC_ALLOC_OPCODE: Opcode =
     opcode::read_write::<dma_heap_allocation_data>(DMA_HEAP_IOC_MAGIC, DMA_HEAP_IOC_ALLOC);

 fn dma_heap_alloc_ioctl(fd: BorrowedFd<'_>, data: &mut dma_heap_allocation_data) -> io::Result<()> {
```